### PR TITLE
Community package manager support (and a few other new features)

### DIFF
--- a/cls/Forgery/Agent.cls
+++ b/cls/Forgery/Agent.cls
@@ -48,5 +48,9 @@ Method Options(settings As %DynamicObject, response As %Stream.Object, outputToD
   return ..Request(settings, .response, outputToDevice)
 }
 
+Method GetLastResponse() As %CSP.Response
+{
+  return ..LastResponse
 }
 
+}

--- a/cls/Forgery/Agent/Core.cls
+++ b/cls/Forgery/Agent/Core.cls
@@ -51,9 +51,9 @@ Method Request(settings As %DynamicObject, response As %Stream.Object, outputToD
   while iter.%GetNext(.key,.value) {
     set type = settings.headers.%GetTypeOf(key)
     if (type = "null") {
-      do finalSettings.%Remove(key)
+      do finalSettings.headers.%Remove(key)
     } else {
-      do finalSettings.%Set(key,value,type)
+      do finalSettings.headers.%Set(key,value,type)
     }
   }
   

--- a/cls/Forgery/Agent/Core.cls
+++ b/cls/Forgery/Agent/Core.cls
@@ -38,13 +38,19 @@ Method Request(settings As %DynamicObject, response As %Stream.Object, outputToD
   set finalSettings = {
     "url": ($zconvert(..BaseURL _ settings.url, "I", "URL")), 
     "method": (settings.method),
-    "headers": (..DefaultHeaders),
+    "headers": {},
     "cookies": (settings.cookies)
   }
 
   if settings.%IsDefined("data") {
     // Don't set {} as data if not defined. (Otherwise, would add content even on GET requests.)
     set finalSettings.data = settings.data
+  }
+
+  set iter = ..DefaultHeaders.%GetIterator()
+  while iter.%GetNext(.key,.value) {
+    set type = ..DefaultHeaders.%GetTypeOf(key)
+    do finalSettings.headers.%Set(key,value,type)
   }
 
   set iter = settings.headers.%GetIterator()

--- a/cls/Forgery/Agent/Core.cls
+++ b/cls/Forgery/Agent/Core.cls
@@ -7,10 +7,18 @@ Property Namespace As %String [ Private ];
 
 Property CookiesJar As %String [ MultiDimensional ];
 
-Method %OnNew() As %Status
+Property BaseURL As %String [ Private ];
+
+Property DefaultHeaders As %DynamicObject [ Private ];
+
+Property LastResponse As %CSP.Response [ Private ];
+
+Method %OnNew(baseURL As %String = "", defaultHeaders As %DynamicObject = {{}}) As %Status
 {
   set ..Namespace = $namespace
   set ..Cache = "^|"""_..Namespace_"""|Forgery.Agent"  
+  set ..BaseURL = baseURL
+  set ..DefaultHeaders = defaultHeaders
   return $$$OK
 }
 
@@ -28,15 +36,20 @@ Method Request(settings As %DynamicObject, response As %Stream.Object, outputToD
   if '$isobject(settings.headers) set settings.headers = {}
   if '$isobject(settings.cookies) set settings.cookies = {}
   
-  set settings = {
-    "url": ($zconvert(settings.url, "I", "URL")), 
+  set finalSettings = {
+    "url": ($zconvert(..BaseURL _ settings.url, "I", "URL")), 
     "method": (settings.method), 
     "data": (settings.data),
-    "headers": (settings.headers),
+    "headers": (..DefaultHeaders),
     "cookies": (settings.cookies)
   }
+
+  set iter = settings.headers.%GetIterator()
+  while iter.%GetNext(.key,.value) {
+    set $Property(finalSettings.headers,key) = value
+  }
   
-  $$$QuitOnError(..Forge(settings, .response))
+  $$$QuitOnError(..Forge(finalSettings, .response))
   
   if outputToDevice = 1 do response.OutputToDevice()  
   return $$$OK
@@ -66,6 +79,7 @@ Method Forge(settings As %DynamicObject, response As %Stream.Object = "", output
   } catch ex {    
     set sc = ex.AsStatus()
   }
+  set ..LastResponse = %response
   kill %request, %session, %response
   
   set $namespace = fromNamespace

--- a/cls/Forgery/Agent/Core.cls
+++ b/cls/Forgery/Agent/Core.cls
@@ -32,21 +32,29 @@ Method Request(settings As %DynamicObject, response As %Stream.Object, outputToD
 {
   set sc = $$$OK
   
-  if '$isobject(settings.data) set settings.data = {}
   if '$isobject(settings.headers) set settings.headers = {}
   if '$isobject(settings.cookies) set settings.cookies = {}
   
   set finalSettings = {
     "url": ($zconvert(..BaseURL _ settings.url, "I", "URL")), 
-    "method": (settings.method), 
-    "data": (settings.data),
+    "method": (settings.method),
     "headers": (..DefaultHeaders),
     "cookies": (settings.cookies)
   }
 
+  if settings.%IsDefined("data") {
+    // Don't set {} as data if not defined. (Otherwise, would add content even on GET requests.)
+    set finalSettings.data = settings.data
+  }
+
   set iter = settings.headers.%GetIterator()
   while iter.%GetNext(.key,.value) {
-    set $Property(finalSettings.headers,key) = value
+    set type = settings.headers.%GetTypeOf(key)
+    if (type = "null") {
+      do finalSettings.%Remove(key)
+    } else {
+      do finalSettings.%Set(key,value,type)
+    }
   }
   
   $$$QuitOnError(..Forge(finalSettings, .response))

--- a/cls/Forgery/Agent/Core.cls
+++ b/cls/Forgery/Agent/Core.cls
@@ -129,11 +129,10 @@ ListToJSON(urlIndex)
   }
 }
 
-ClassMethod ClearCookies() As %Status
+Method ClearCookies() As %Status
 {
   set i%CookiesJar = ""
   return $$$OK
 }
 
 }
-

--- a/cls/Forgery/OutputCapturer.cls
+++ b/cls/Forgery/OutputCapturer.cls
@@ -24,7 +24,15 @@ ClassMethod Capture(dispatcherClass As %String, url As %String, httpMethod As %S
     do ##class(%Device).ReDirectIO(1)
     use $io::("^"_$zname)
     set isRedirected = 1
-    set sc = $classmethod(dispatcherClass, "DispatchRequest", url, httpMethod)
+    try {
+      set sc = $classmethod(dispatcherClass, "DispatchRequest", url, httpMethod)
+    } catch e {
+      set sc = e.AsStatus()
+    }
+    if $$$ISERR(sc) {
+      set %response.OutputSessionToken=0
+      do $classmethod(dispatcherClass, "Http500", ##class(%Exception.StatusException).CreateFromStatus(sc))
+    }
     do str.Rewind()
   } catch ex {
     set str = ""
@@ -51,4 +59,3 @@ rchr(time) Quit ""
 }
 
 }
-

--- a/module.xml
+++ b/module.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="Cache" version="25">
+<Document name="Forgery.ZPM"><Module>
+  <Name>Forgery</Name>
+  <Version>1.1.3</Version>
+  <Packaging>module</Packaging>
+  <Resource Name="Forgery.PKG" />
+  <LifecycleClass>Module</LifecycleClass>
+</Module>
+</Document></Export>


### PR DESCRIPTION
I've forked this for my own use in some unit tests and would like to propose a few changes for the "official" version. Happy to discuss, of course! (Or to re-submit as individual smaller PRs if you would prefer that.)

Changes include:
- Support for the community package manager (zpm)
- Allowing a base URL and default set of headers to be specified when an Agent is created
- Allowing retrieval of the last %response object (for verification of %response.Status or of headers in unit tests, for example)
- Reporting/handling errors by the same means as %CSP.REST (as JSON / HTTP 500 via Http500 method of dispatch class; also still reported as a %Status for backward-compatibility)
- Fixing ClearCookies to be an instance method so it compiles